### PR TITLE
Change west.yml hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
             zephyr/
             bootloader/
             zmk/
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('manifest-dir/west.yml') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/west.yml') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-


### PR DESCRIPTION
The `hashFiles('manifest-dir/west.yml')` function will not produce hash string; something that was uncovered while troubleshooting corrupted cache modules. `hashFiles('**/west.yml')` will correctly the file to generate the appropriate cache hash.