### PR TITLE
feat: Add Zephyr module support.

### DIFF
--- a/config/west.yml
+++ b/config/west.yml
@@ -2,6 +2,8 @@ manifest:
   remotes:
     - name: zmkfirmware
       url-base: https://github.com/zmkfirmware
+  # Additional modules containing boards/shields/custom code can be listed here as well
+  # See https://docs.zephyrproject.org/latest/develop/west/manifest.html#projects
   projects:
     - name: zmk
       remote: zmkfirmware

--- a/config/west.yml
+++ b/config/west.yml
@@ -2,8 +2,8 @@ manifest:
   remotes:
     - name: zmkfirmware
       url-base: https://github.com/zmkfirmware
-  # Additional modules containing boards/shields/custom code can be listed here as well
-  # See https://docs.zephyrproject.org/latest/develop/west/manifest.html#projects
+    # Additional modules containing boards/shields/custom code can be listed here as well
+    # See https://docs.zephyrproject.org/3.2.0/develop/west/manifest.html#projects
   projects:
     - name: zmk
       remote: zmkfirmware

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,3 @@
+build:
+  settings:
+    board_root: .


### PR DESCRIPTION
Needed as part of zmkfirmware/zmk#1989 so that new repos created from this will be properly structured for adding custom boards/shields that can also be referenced by pulling this repo in as a Zephyr module.