### PR TITLE
docs: Give examples of using other build.yaml props

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,9 @@
-# This file generates the GitHub Actions matrix
-# For simple board + shield combinations, add them
-# to the top level board and shield arrays, for more
-# control, add individual board + shield combinations to
-# the `include` property, e.g:
+# This file generates the GitHub Actions matrix.
+# For simple board + shield combinations, add them to the top level board and
+# shield arrays, for more control, add individual board + shield combinations
+# to the `include` property. You can also use the `cmake-args` property to
+# pass flags to the build command and `artifact-name` to assign a name to
+# distinguish build outputs from each other:
 #
 # board: [ "nice_nano_v2" ]
 # shield: [ "corne_left", "corne_right" ]
@@ -10,5 +11,9 @@
 #   - board: bdn9_rev2
 #   - board: nice_nano_v2
 #     shield: reviung41
+#   - board: nice_nano_v2
+#     shield: corne_left
+#     cmake-args: -DCONFIG_ZMK_USB_LOGGING=y
+#     artifact-name: corne_left_with_logging
 #
 ---


### PR DESCRIPTION
Following up on zmkfirmware/zmk#2015, add an example using `cmake-args` and `artifact-name` to the comment blurb in build.yaml.

Here I used an alternate keymap example since that request comes up, e.g. https://github.com/zmkfirmware/zmk/issues/1931. However it isn't the most straightforward since the path seems to be relative to `zmk/app`, hence the `../..`. Also `KEYMAP_FILE` isn't a documented arg.

An alternative would be to set a Kconfig for that build. Would that be preferable? If so, I can replace this with e.g. `-DCONFIG_ZMK_USB_LOGGING=y`.