### PR TITLE
Add name to build.yaml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+name: Build ZMK firmware
 on: [push, pull_request, workflow_dispatch]
 
 jobs:


### PR DESCRIPTION
Adding a default name to build.yaml. Without name, the action is labeled as the full path.
![image](https://github.com/zmkfirmware/unified-zmk-config-template/assets/7746625/d37aedc9-06e7-45ee-9780-7fcd5706b101)
