### PR TITLE
refactor: Remove outdated logging conf in example

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2,8 +2,8 @@
 # For simple board + shield combinations, add them to the top level board and
 # shield arrays, for more control, add individual board + shield combinations
 # to the `include` property. You can also use the `cmake-args` property to
-# pass flags to the build command and `artifact-name` to assign a name to
-# distinguish build outputs from each other:
+# pass flags to the build command, `snippet` to add a Zephyr snippet, and
+# `artifact-name` to assign a name to distinguish build outputs from each other:
 #
 # board: [ "nice_nano_v2" ]
 # shield: [ "corne_left", "corne_right" ]
@@ -13,7 +13,8 @@
 #     shield: reviung41
 #   - board: nice_nano_v2
 #     shield: corne_left
-#     cmake-args: -DCONFIG_ZMK_USB_LOGGING=y
-#     artifact-name: corne_left_with_logging
+#     snippet: studio-rpc-usb-uart
+#     cmake-args: -DCONFIG_ZMK_STUDIO=y
+#     artifact-name: corne_left_with_studio
 #
 ---


### PR DESCRIPTION
The logging example is now invalid, since it needs a snippet. Changed it to a Studio one since we can show both snippet and cmake-args examples with that.